### PR TITLE
Optimize order of provers to reduce proof time

### DIFF
--- a/sparknacl_common.gpr
+++ b/sparknacl_common.gpr
@@ -33,11 +33,12 @@ project SPARKNaCl_Common is
                                       "--no-counterexample",
                                       "--no-loop-unrolling",
                                       "--level=4",
-                                      "--prover=cvc4,z3",
+                                      "--prover=z3,cvc4",
                                       "--timeout=0",
                                       "--memlimit=0",
                                       "--steps=14000",
                                       "--report=statistics");
+      for Proof_Switches ("sparknacl-utils.adb") use ("--prover=cvc4,z3");
    end Prove;
 
    package Builder is


### PR DESCRIPTION
Use of the tool SPAT showed that a lot of time was spend by CVC4 on some VC
that Z3 could prove easily. Changing the order was not a home run though, as
Z3 runs a long time on some VC in sparknack-utils.adb. Solution is to
special-case this unit to run the provers in the other order. On my laptop,
running time goes from 1 mn 50 s to 1 mn 3 s.