### PR TITLE
Merge changes needed for Gnat 12.1.1

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -11,7 +11,7 @@ maintainers = ["Rod Chapman <rod@proteancode.com>"]
 maintainers-logins = ["rod-chapman"]
 
 [[depends-on]]
-gnat=">=11.2.1"
+gnat=">=12.1.1"
 
 [gpr-externals]
 SPARKNACL_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]
@@ -22,3 +22,5 @@ SPARKNACL_CONTRACTS = ["enabled", "disabled"]
 SPARKNACL_RUNTIME_MODE = ["full", "zfp"]
 SPARKNACL_BUILD_MODE = ["debug", "O1", "O2", "O3", "Os"]
 SPARKNACL_TARGET_ARCH = ["unspecified", "rv32im", "rv32imc", "rv32imc_a4"]
+[[depends-on]]
+gnatprove = "=12.1.1"

--- a/perf/perf.gpr
+++ b/perf/perf.gpr
@@ -36,10 +36,13 @@ abstract project Perf is
 
   package Compiler is
 
+    for Default_Switches ("Asm") use Compiler'Default_Switches ("Asm") &
+        ("-march=rv32imac_zicsr");
+
     for Default_Switches ("C") use Compiler'Default_Switches ("C") &
         Callgraph_Switch &
         Opt_Switch &
-        ("-march=rv32im",       -- No compressed instructions for C
+        ("-march=rv32imac_zicsr",
          "-ffunction-sections", -- Create a linker section for each function
          "-fdata-sections");    -- Create a linker section for each data
 
@@ -55,7 +58,7 @@ abstract project Perf is
          "-gnatRms", -- Output representation info for subprograms
          "-gnatQ",   -- Don't quit. Generate ALI and tree files even if illegalities
          "-gnatw.X", -- Disable warnings for No_Exception_Propagation
-         "-march=rv32im", -- No compressed instructions please
+         "-march=rv32imac_zicsr",
          "-ffunction-sections", -- Create a linker section for each function
          "-fdata-sections");    -- Create a linker section for each data
   end Compiler;

--- a/perf/tsign.gpr
+++ b/perf/tsign.gpr
@@ -4,7 +4,8 @@ with "perf.gpr";
 
 project TSign is
 
-  for Runtime ("ada") use HiFive1_rev_B_ZFP'Runtime ("Ada");
+--  for Runtime ("ada") use HiFive1_rev_B_ZFP'Runtime ("Ada");
+  for Runtime ("ada") use "light-rv32imac";
   for Target use "riscv64-elf";
   for Languages use ("Ada", "C", "Asm");
   for Source_Dirs use (".");

--- a/perf/tsign.mk
+++ b/perf/tsign.mk
@@ -1,5 +1,7 @@
 all: tsign.hex tsign.asm
 
+PLAT := $(shell uname -s)
+
 SIZE_OBJS := ../obj/sparknacl.o ../obj/sparknacl-car.o ../obj/sparknacl-core.o ../obj/sparknacl-cryptobox.o ../obj/sparknacl-hashing.o ../obj/sparknacl-mac.o ../obj/sparknacl-scalar.o ../obj/sparknacl-secretbox.o ../obj/sparknacl-sign.o ../obj/sparknacl-sign-utils.o ../obj/sparknacl-stream.o ../obj/sparknacl-utils.o
 
 tsign: tsign.adb io.adb io.ads tweetnacl_api.ads tweetnacl.c
@@ -26,8 +28,12 @@ size:	tsign
 	riscv64-elf-size -t $(SIZE_OBJS)
 
 run: tsign.hex
+ifeq ($(PLAT),Darwin)
+	-cp tsign.hex /Volumes/HiFive
+else # assumed to be some sort of Linux
 	-cp tsign.hex /media/psf/HiFive
 	-cp tsign.hex /media/rchapman/HiFive
+endif
 
 clean:
 	rm -f tsign.hex


### PR DESCRIPTION
This PR covers changes to the library, build and performance tests needed to compiler with FSF GNAT 12.1.1 (from the Alire repository) on both MacOS and Linux.
