### PR TITLE
Update SPARK switches and solvers. We have 5 potential non-terminations

### DIFF
--- a/sparknacl.gpr
+++ b/sparknacl.gpr
@@ -144,19 +144,17 @@ library project Sparknacl is
    end Binder;
 
    package Prove is
-      for Proof_Switches ("Ada") use ("--proof=per_path",
-                                      "-j6",
+      for Proof_Switches ("Ada") use ("--proof=progressive:all",
+                                      "-j12",
                                       "--no-global-generation",
                                       "--no-inlining",
                                       "--no-loop-unrolling",
-                                      "--level=1",
-                                      "--prover=z3,cvc4,altergo",
+                                      "--level=4",
+                                      "--prover=z3,cvc5,altergo",
                                       "--timeout=60",
                                       "--memlimit=0",
-                                      "--steps=200000",
+                                      "--steps=2000000",
                                       "--report=statistics");
-      for Proof_Switches ("sparknacl-car.adb") use ("--prover=altergo,z3,cvc4");
-      for Proof_Switches ("sparknacl-utils.adb") use ("--prover=altergo,z3,cvc4"); -- ok with CE 2021
    end Prove;
 
 


### PR DESCRIPTION
This is a simple update to the GNATProve flags so that newer versions can be used. I also increased the level and steps in order to see if I could help the medium-level warnings on non-termination, but those did not help.

My actual goal was to see if we could do two normalization steps on GF instead of three with the newer provers and GNATProve version. Alas, I am not knowledgeable to understand the code and see what I would need to do in order to go from three to two :) But I think this could be an interesting test to carry out and see how well the new provers perform.

I tested this with GCC/GNAT/GNATProve v14 as provided by Alire.

Best regards,
Fer